### PR TITLE
chore(make_dev_link): 创建软连接类型改为dir

### DIFF
--- a/scripts/make_dev_link.js
+++ b/scripts/make_dev_link.js
@@ -111,7 +111,7 @@ if (fs.existsSync(targetPath)) {
     log(`Failed! Target directory  ${targetPath} already exists`);
 } else {
     //创建软链接
-    fs.symlinkSync(`${process.cwd()}/dev`, targetPath, 'junction');
+    fs.symlinkSync(`${process.cwd()}/dev`, targetPath, 'dir');
     log(`Done! Created symlink ${targetPath}`);
 }
 

--- a/src/creater/createIndex.ts
+++ b/src/creater/createIndex.ts
@@ -113,7 +113,6 @@ export async function insertDocButton() {
     let outlineData = await requestGetDocOutline(parentId);
     // console.log(outlineData);
     data = insertOutline(data, outlineData, 0, 0);
-
     if (data != '') {
         await insertData(parentId, data, "outline");
     } else {
@@ -345,7 +344,7 @@ function insertOutline(data: string, outlineData: any[], tab: number, stab: numb
 
 //获取图标
 export function getSubdocIcon(icon: string, hasChild: boolean) {
-    console.log(icon);
+    // console.log("getSubdocIcon", icon, 'hasChild', hasChild);
     if (icon == '' || icon == undefined) {
         return hasChild ? "📑" : "📄";
     } else if (icon.indexOf(".") != -1) {
@@ -356,12 +355,14 @@ export function getSubdocIcon(icon: string, hasChild: boolean) {
             let removeFileFormat = icon.substring(0, icon.lastIndexOf("."));
             return `:${removeFileFormat}:`;
         }
+    } else if (icon.includes("api/icon/getDynamicIcon")) {
+        return `![](${icon})`;
     } else {
         let result = "";
         icon.split("-").forEach(element => {
             result += String.fromCodePoint(parseInt(element, 16))
         });
-        console.log(result);
+        // console.log("getSubdocIcon result", result);
         return result;
     }
 }
@@ -645,7 +646,7 @@ function queuePopAll(queue: IndexQueue, data: string) {
             }
         }
         data += item.text;
-        // console.log(item.text);
+        // console.log("queuePopAll", item.text);
 
         if (!item.children.isEmpty()) {
             data = queuePopAll(item.children, data);


### PR DESCRIPTION
思源升级了 Go 1.23，旧版创建的 junction link 在 windows 下无法被正常识别，故而改为创建 dir 符号链接