### PR TITLE
禁用部分日志输出

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Left-click to insert a directory list; right-click for more actions.
 
 **Experimental Feature**: After adding to the database, use `alt + click` on cells to batch configure attributes.
 
-<img src="./asset/guide-create-db.jpg" width="500" />
+<img src="https://github.com/Szerelem0617/siyuan-plugins-index/blob/main/asset/guide-create-db.jpg" width="500" />
 
 # Changelog
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -15,7 +15,7 @@
 为目录以及其它列表创建数据库。
 加入数据库后，可通过 `alt + click` 单元格来批量配置属性。
 
-<img src="./asset/guide-create-db.jpg" width="500" />
+<img src="https://github.com/Szerelem0617/siyuan-plugins-index/blob/main/asset/guide-create-db.jpg" width="500" />
 
 # 1.9.15 版本更新
 
@@ -34,7 +34,7 @@
 
 - 微信赞赏: (备注微信号)
   
-  <img src="./asset/qr.jpg" width="200" />
+  <img src="https://github.com/Szerelem0617/siyuan-plugins-index/blob/main/asset/qr.jpg" width="200" />
 
 # 致谢
 

--- a/src/core/slash.ts
+++ b/src/core/slash.ts
@@ -33,7 +33,7 @@ export function addSlash() {
         id: "insertIndex",
         async callback(_protyle: Protyle) {
             const blockId = getCurrentBlockId();
-            console.log("[IndexPlugin] Slash insertIndex - blockId found:", blockId);
+            // console.log("[IndexPlugin] Slash insertIndex - blockId found:", blockId);
             // NOTE: SiYuan clears the slash "/" text from the block BEFORE calling this callback.
             // Do NOT call protyle.insert("") here — it sends a redundant write that races with
             // our updateBlock call and can cause the index content to be lost on quick exit/file move.
@@ -45,7 +45,7 @@ export function addSlash() {
         id: "insertOutline",
         async callback(_protyle: Protyle) {
             const blockId = getCurrentBlockId();
-            console.log("[IndexPlugin] Slash insertOutline - blockId found:", blockId);
+            // console.log("[IndexPlugin] Slash insertOutline - blockId found:", blockId);
             await insertOutlineAction(blockId);
         }
     }];

--- a/src/events/emoji-event.ts
+++ b/src/events/emoji-event.ts
@@ -25,7 +25,7 @@ async function handleAltClick(event: MouseEvent) {
     // Ignore the fixed separator character
     if (textContent === "➖") return;
 
-    console.log("handleAltClick - textContent:", textContent); // Debug log
+    // console.log("handleAltClick - textContent:", textContent); // Debug log
 
     // Matches:
     // 1. Flags: \p{RI}\p{RI}

--- a/src/features/builder/auto-update.ts
+++ b/src/features/builder/auto-update.ts
@@ -52,7 +52,7 @@ export async function autoUpdateBuilder(parentId: string, existingBlock?: any) {
                 }
             }
         } else {
-            console.log(`[Builder] custom-tree-create attribute not found in IAL: ${block.ial}`);
+            // console.log(`[Builder] custom-tree-create attribute not found in IAL: ${block.ial}`);
         }
     } catch (e) {
         console.error("[Builder] Failed to parse tree attribute", e);
@@ -61,7 +61,7 @@ export async function autoUpdateBuilder(parentId: string, existingBlock?: any) {
     // Check Auto Update Settings
     // Respect only local setting. If missing, assume true if the attribute exists.
     if (localAutoUpdate === false) {
-        console.log("[Builder] Auto-update disabled locally.");
+        // console.log("[Builder] Auto-update disabled locally.");
         return;
     }
 

--- a/src/features/builder/builder.ts
+++ b/src/features/builder/builder.ts
@@ -133,7 +133,7 @@ export class ListProcessor {
             const core = this.ibp.parseItemContent(child.id, pBlocks);
 
             if (!core) {
-                console.log(`[Builder] Item ${child.id} could not be parsed. Skipping.`);
+                // console.log(`[Builder] Item ${child.id} could not be parsed. Skipping.`);
                 continue;
             }
 

--- a/src/features/builder/processor.ts
+++ b/src/features/builder/processor.ts
@@ -326,7 +326,7 @@ export class IBlockProcessor {
             let notebook, path, hpath;
             try {
                 const pathRes = await post("/api/filetree/getPathByID", { id: docId });
-                console.log(`[Builder-Debug] getPathByID for docId ${docId} returned:`, pathRes);
+                // console.log(`[Builder-Debug] getPathByID for docId ${docId} returned:`, pathRes);
                 if (pathRes) {
                     notebook = pathRes.notebook;
                     path = pathRes.path;

--- a/src/features/command/command-dispatcher.ts
+++ b/src/features/command/command-dispatcher.ts
@@ -71,7 +71,7 @@ export async function dispatchCommand(
 
     // 3. 构建参数
     const resolvedParams = await buildParams(def, rawParam, context);
-    console.log(`[Dispatcher] "${commandId}" params resolved:`, resolvedParams);
+    // console.log(`[Dispatcher] "${commandId}" params resolved:`, resolvedParams);
 
     // 4. 按 dispatch.method 执行
     try {
@@ -179,7 +179,7 @@ function dispatchKeyboard(def: CommandDef, context: CommandContext): DispatchRes
         return { success: false, method: "keyboard", detail: `Failed to synthesize event for hotkey: ${hotkey}` };
     }
 
-    console.log(`[Dispatcher] keyboard → ${def.id} | key="${keyEvent.key}" ctrl=${keyEvent.ctrlKey} meta=${keyEvent.metaKey}`);
+    // console.log(`[Dispatcher] keyboard → ${def.id} | key="${keyEvent.key}" ctrl=${keyEvent.ctrlKey} meta=${keyEvent.metaKey}`);
     synthTarget.dispatchEvent(keyEvent);
     return { success: true, method: "keyboard", detail: hotkey };
 }
@@ -189,7 +189,7 @@ function dispatchGlobal(def: CommandDef): DispatchResult {
     if (!target) {
         return { success: false, method: "global", detail: "No target defined for global command." };
     }
-    console.log(`[Dispatcher] global  → globalCommand("${target}")`);
+    // console.log(`[Dispatcher] global  → globalCommand("${target}")`);
     globalCommand(target, plugin.app);
     return { success: true, method: "global", detail: target };
 }
@@ -210,7 +210,7 @@ async function dispatchApi(
         body.id = context.blockEl.getAttribute("data-node-id") ?? undefined;
     }
 
-    console.log(`[Dispatcher] api     → POST ${endpoint}`, body);
+    // console.log(`[Dispatcher] api     → POST ${endpoint}`, body);
     const result = await post(endpoint, body);
     return { success: true, method: "api", detail: `${endpoint} OK` };
 }
@@ -224,7 +224,7 @@ async function dispatchCustom(
     if (typeof executor !== "function") {
         return { success: false, method: "custom", detail: `No executor registered for: ${def.id}` };
     }
-    console.log(`[Dispatcher] custom  → ${def.id}`);
+    // console.log(`[Dispatcher] custom  → ${def.id}`);
     await executor(params, context);
     return { success: true, method: "custom", detail: def.id };
 }

--- a/src/features/command/construct-dir.ts
+++ b/src/features/command/construct-dir.ts
@@ -26,7 +26,7 @@ export async function constructCommandStorage() {
             targetNotebookId = res.notebook.id;
             await sleep(500);
         } else {
-            console.log(`[IndexOS] Existing notebook found: ${targetNotebookId}`);
+            // console.log(`[IndexOS] Existing notebook found: ${targetNotebookId}`);
         }
 
         // 2. Init Command-DB (逻辑工厂)
@@ -204,7 +204,7 @@ async function initDbDoc(
                 markdown: initMarkdown
             });
             docId = createRes;
-            console.log(`[IndexOS] Created doc ${docId} for ${docName}.`);
+            // console.log(`[IndexOS] Created doc ${docId} for ${docName}.`);
         } catch (e) {
             console.error(`[IndexOS] createDocWithMd failed for ${docName}`, e);
         }
@@ -242,12 +242,12 @@ async function initDbDoc(
                 const avId = newAttrs["custom-index-linked-av"];
 
                 if (avId) {
-                    console.log(`[IndexOS] DB created with avID: ${avId}, injecting columns...`);
+                    // console.log(`[IndexOS] DB created with avID: ${avId}, injecting columns...`);
                     await initColsCallback(avId);
                     console.log(`[IndexOS] DB columns initialized for ${docName}.`);
                 }
             } else {
-                console.log(`[IndexOS] DB already exists and linked for ${docName}.`);
+                // console.log(`[IndexOS] DB already exists and linked for ${docName}.`);
             }
         } else {
             console.warn(`[IndexOS] Failed to find the list block in ${docName} for DB conversion.`);

--- a/src/features/command/global-registration/button-link.ts
+++ b/src/features/command/global-registration/button-link.ts
@@ -47,8 +47,8 @@ function handleAvAltClick(event: MouseEvent) {
 
     // 5. 查找对应的 Command ID
     // 我们可以打印一下当前的注册表状态和获取到的 Label，方便调试
-    console.log("[ButtonLink] Clicked Label:", `"${cleanLabel}"`);
-    console.log("[ButtonLink] Registry Keys:", Object.keys(COMMAND_REGISTRY));
+    // console.log("[ButtonLink] Clicked Label:", `"${cleanLabel}"`);
+    // console.log("[ButtonLink] Registry Keys:", Object.keys(COMMAND_REGISTRY));
 
     // 尝试直接匹配
     let cmdInfo = COMMAND_REGISTRY[cleanLabel];
@@ -60,7 +60,7 @@ function handleAvAltClick(event: MouseEvent) {
         );
         if (foundKey) {
             cmdInfo = COMMAND_REGISTRY[foundKey];
-            console.log("[ButtonLink] Fuzzy match found via key:", foundKey);
+            // console.log("[ButtonLink] Fuzzy match found via key:", foundKey);
         }
     }
 

--- a/src/features/command/global-registration/inline-button.ts
+++ b/src/features/command/global-registration/inline-button.ts
@@ -180,7 +180,7 @@ export function handleInlineButtonClick(event: MouseEvent) {
         return;
     }
 
-    console.log("[InlineButton] Click:", payload);
+    // console.log("[InlineButton] Click:", payload);
 
     // ── 配置模式 ──────────────────────────────────────────────────────────
     if (payload.command === "sys.configure") {
@@ -216,7 +216,7 @@ export function handleInlineButtonClick(event: MouseEvent) {
  */
 export function handleBtnPaste(event: CustomEvent) {
     const { textPlain, resolve } = event.detail;
-    console.log("[BtnPaste] hook called, textPlain=", textPlain?.slice(0, 80));
+    // console.log("[BtnPaste] hook called, textPlain=", textPlain?.slice(0, 80));
 
     if (!textPlain?.startsWith(PROTOCOL)) {
         // 与本功能无关，不调用 resolve，让思源循原生流程继续
@@ -226,9 +226,9 @@ export function handleBtnPaste(event: CustomEvent) {
     // 告诉 EventBus 我们接管了此事件（dispatchEvent 返回 false，阻止 paste.ts 抢先 resolve(undefined)）
     event.preventDefault();
 
-    console.log("[BtnPaste] detected siyuan-btn link, decoding...");
+    // console.log("[BtnPaste] detected siyuan-btn link, decoding...");
     const payload = decodeBtnHref(textPlain.trim());
-    console.log("[BtnPaste] decoded payload=", payload);
+    // console.log("[BtnPaste] decoded payload=", payload);
 
     if (!payload) {
         console.warn("[BtnPaste] decode failed, fallback");
@@ -240,7 +240,7 @@ export function handleBtnPaste(event: CustomEvent) {
     let displayName = payload.command;
     if (payload.command !== "sys.configure") {
         const def = commandRegistry.findByNameOrId(payload.command);
-        console.log("[BtnPaste] findByNameOrId result=", def?.id, def?.name);
+        // console.log("[BtnPaste] findByNameOrId result=", def?.id, def?.name);
         if (def) displayName = def.name;
     }
 

--- a/src/features/command/indexos/command-sqlite.ts
+++ b/src/features/command/indexos/command-sqlite.ts
@@ -36,7 +36,7 @@ export async function initSystemTables() {
     // 3. Check if empty and seed default data
     const cmdCount = db.exec(`SELECT count(*) FROM ${TABLE_COMMANDS}`)[0].values[0][0];
     if (cmdCount === 0) {
-        console.log("[SQLite-IndexOS] Seeding default commands...");
+        // console.log("[SQLite-IndexOS] Seeding default commands...");
         const defaultCmds = [
             ["general.graphView", "全局关系图", "general.graphView", "", "Native", "Global", 1, 1, 1],
             ["general.inbox", "收集箱", "general.inbox", "", "Native", "Global", 0, 0, 1],
@@ -54,8 +54,8 @@ export async function initSystemTables() {
 
     const typeCount = db.exec(`SELECT count(*) FROM ${TABLE_TYPES}`)[0].values[0][0];
     if (typeCount === 0) {
-        console.log("[SQLite-IndexOS] Seeding default type bindings...");
-        db.run(`INSERT INTO ${TABLE_TYPES} (supertag, blockIconMenu, pageMenu) VALUES (?, ?, ?)`, 
+        // console.log("[SQLite-IndexOS] Seeding default type bindings...");
+        db.run(`INSERT INTO ${TABLE_TYPES} (supertag, blockIconMenu, pageMenu) VALUES (?, ?, ?)`,
             ["project", "在右侧分屏打开, 全局关系图", "全局关系图"]);
     }
 

--- a/src/features/command/registration.ts
+++ b/src/features/command/registration.ts
@@ -114,7 +114,7 @@ async function refreshRegistryFromSqlite(): Promise<boolean> {
         }
 
         SUPERTAG_REGISTRY = newRegistry;
-        console.log(`[SQLite-IndexOS] Registry refreshed from Source of Truth. Commands: ${Object.keys(COMMAND_REGISTRY).length}, Supertags: ${SUPERTAG_REGISTRY.length}`);
+        // console.log(`[SQLite-IndexOS] Registry refreshed from Source of Truth. Commands: ${Object.keys(COMMAND_REGISTRY).length}, Supertags: ${SUPERTAG_REGISTRY.length}`);
         return true;
     } catch (e) {
         console.error("[SQLite-IndexOS] Failed to refresh registry from SQL:", e);
@@ -254,7 +254,7 @@ export function getInitSystemSlashCommand() {
             html: `<div class="b3-list-item__first"><span class="b3-list-item__text">${i18n.initSystemDB}</span><span class="b3-list-item__meta">Legacy AV</span></div>`,
             id: "initSystemDB",
             async callback(protyle: Protyle) {
-                console.log("[IndexPlugin] Slash initSystemDB");
+                // console.log("[IndexPlugin] Slash initSystemDB");
                 protyle.insert("");
                 await constructCommandStorage();
                 await refreshSupertagRegistry();
@@ -358,7 +358,7 @@ export function addCommandTestMenuItem({ detail }: any) {
                         try { (window as any).siyuan?.menus?.menu?.remove(); }
                         catch (_) { document.querySelectorAll(".b3-menu").forEach((m: any) => m.remove()); }
 
-                        console.log(`[IndexOS] 🚀 Dispatching [${match.commandRef}] via Supertag Cache`);
+                        // console.log(`[IndexOS] 🚀 Dispatching [${match.commandRef}] via Supertag Cache`);
 
                         setTimeout(async () => {
                             try {

--- a/src/features/command/registry/command-registry.ts
+++ b/src/features/command/registry/command-registry.ts
@@ -173,7 +173,7 @@ class CommandRegistry {
             console.warn(`[Registry] Command "${def.id}" is being overwritten.`);
         }
         this.store.set(def.id, def);
-        console.log(`[Registry] Registered: ${def.id} (${def.meta.source})`);
+        // console.log(`[Registry] Registered: ${def.id} (${def.meta.source})`);
     }
 
     /**

--- a/src/features/data/attribute-view/special/special-handlers.ts
+++ b/src/features/data/attribute-view/special/special-handlers.ts
@@ -102,7 +102,7 @@ function renderPreviewAsset(path: string, previewEl: HTMLElement) {
  */
 export async function updateCellValue(protyleInstance: any, avID: string, rowID: string, colID: string, newValue: string) {
     try {
-        console.log(`[Data] Updating cell: Row [${rowID}], Col [${colID}]`, { newValue });
+        // console.log(`[Data] Updating cell: Row [${rowID}], Col [${colID}]`, { newValue });
         const avData = await post("/api/av/renderAttributeView", { id: avID, pageSize: 1000 });
         const view = avData.view || avData;
         const rows = view.rows || [];
@@ -339,9 +339,9 @@ export function openTemplateDialog(protyleInstance: any, avID: string, rowID: st
 
     const renderList = (keyword = "") => {
         listEl.innerHTML = '<div class="fn__loading" style="padding: 20px;"><img width="32px" src="/stage/loading-pure.svg"></div>';
-        console.log(`[SpecialHandlers] Searching template with keyword: "${keyword}"`);
+        // console.log(`[SpecialHandlers] Searching template with keyword: "${keyword}"`);
         post("/api/search/searchTemplate", { k: keyword }).then((res: any) => {
-            console.log(`[SpecialHandlers] Search results:`, res);
+            // console.log(`[SpecialHandlers] Search results:`, res);
             let html = "";
             const templates = res.templates || [];
             if (templates.length > 0) {
@@ -358,7 +358,7 @@ export function openTemplateDialog(protyleInstance: any, avID: string, rowID: st
                 html = `<div class="b3-list--empty" style="padding: 16px; text-align: center; color: var(--b3-theme-on-surface-light);">无匹配模板</div>`;
             }
             listEl.innerHTML = html;
-            console.log(`[SpecialHandlers] Total templates found: ${templates.length}`);
+            // console.log(`[SpecialHandlers] Total templates found: ${templates.length}`);
 
             const firstItem = listEl.querySelector(".b3-list-item") as HTMLElement;
             if (firstItem) {

--- a/src/features/data/attribute-view/sync/attribute-sync.ts
+++ b/src/features/data/attribute-view/sync/attribute-sync.ts
@@ -89,12 +89,12 @@ export async function syncAttribute(avID: string, rowID: string, colID: string, 
                 const lastSegment = segments[segments.length - 1];
                 const currentIdInPath = lastSegment.replace(/^\d{3}-/, "");
                 const identityPrefix = segments.slice(0, -1).join("/") + "/" + currentIdInPath + "/";
-                
-                console.log(`[Sync-Debug] Descendants Mode:`, {
-                    sourceBlockID,
-                    sourcePath,
-                    identityPrefix
-                });
+
+                // console.log(`[Sync-Debug] Descendants Mode:`, {
+                //     sourceBlockID,
+                //     sourcePath,
+                //     identityPrefix
+                // });
 
                 targetItemIDs = Array.from(pathCellMap.entries())
                     .filter(([bid, cell]) => {
@@ -102,8 +102,8 @@ export async function syncAttribute(avID: string, rowID: string, colID: string, 
                         return p && p.startsWith(identityPrefix) && bid !== sourceBlockID;
                     })
                     .map(([bid]) => bid);
-                
-                console.log(`[Sync-Debug] Target Item IDs found: ${targetItemIDs.length}`);
+
+                // console.log(`[Sync-Debug] Target Item IDs found: ${targetItemIDs.length}`);
             } else {
                 console.error(`[Sync-Debug] sourceID ${sourceBlockID} not found in Path map. Map size: ${pathCellMap.size}`);
                 throw new Error("无法获取当前项的路径数据");
@@ -121,7 +121,7 @@ export async function syncAttribute(avID: string, rowID: string, colID: string, 
         
         if (mode !== "filtered") {
             try {
-                console.log(`[Sync-V2] Mapping ${targetItemIDs.length} BlockIDs via Kernel...`);
+                // console.log(`[Sync-V2] Mapping ${targetItemIDs.length} BlockIDs via Kernel...`);
                 const mappingRes = await post("/api/av/getAttributeViewItemIDsByBoundIDs", {
                     avID: avID,
                     blockIDs: targetItemIDs
@@ -145,7 +145,7 @@ export async function syncAttribute(avID: string, rowID: string, colID: string, 
             value: syncValue
         }));
 
-        console.log(`[Sync-V2] Batch updating ${updateValues.length} items. First ItemID: ${updateValues[0].itemID}`);
+        // console.log(`[Sync-V2] Batch updating ${updateValues.length} items. First ItemID: ${updateValues[0].itemID}`);
 
         // 分批执行更新 (每批 50 条) 以保证稳定性，参考 create-db.ts
         const chunkSize = 50;

--- a/src/features/data/av-setting/db-config.ts
+++ b/src/features/data/av-setting/db-config.ts
@@ -16,7 +16,7 @@ import { type DbConfig, type TypeConfig } from "./types";
 
 export async function syncInheritanceToDb(avId: string, config: DbConfig, avBlockId?: string) {
     if (!config.inheritanceRules || config.inheritanceRules.length === 0) {
-        console.log("[Materialized Sync] No inheritance rules defined. Skipping.");
+        // console.log("[Materialized Sync] No inheritance rules defined. Skipping.");
         return;
     }
 

--- a/src/features/data/list/auto-update.ts
+++ b/src/features/data/list/auto-update.ts
@@ -17,12 +17,12 @@ export async function autoUpdateListAVs(listBlock: any) {
         // --- 1. 继承回填 (独立逻辑) ---
         // 只要存在绑定关系，每次激活页签都尝试进行轻量级的继承同步（内部有 dirty check）
         if (avId && avBlockId) {
-            console.log(`[Auto-Update-Debug] Tab Activated. Checking inheritance for AV ${avId}...`);
+            // console.log(`[Auto-Update-Debug] Tab Activated. Checking inheritance for AV ${avId}...`);
             const config = await loadDbConfig(avBlockId);
             if (config && config.inheritanceRules && config.inheritanceRules.length > 0) {
                 const updatedCount = await syncInheritanceToDb(avId, config, avBlockId);
                 if (updatedCount > 0) {
-                    console.log(`[Auto-Update-Debug] Inheritance auto-applied: ${updatedCount} fields updated.`);
+                    // console.log(`[Auto-Update-Debug] Inheritance auto-applied: ${updatedCount} fields updated.`);
                 }
             }
         }

--- a/src/features/data/list/create-db.ts
+++ b/src/features/data/list/create-db.ts
@@ -47,7 +47,7 @@ async function fetchDocumentIconsForDBItems(targetIds: string[]): Promise<Record
     const formattedIds = targetIds.filter(id => id).map(id => `'${id}'`);
     if (formattedIds.length === 0) return itemPropsMap;
 
-    console.log(`[Data-Debug] fetchDocumentIconsForDBItems requested for ${formattedIds.length} items`);
+    // console.log(`[Data-Debug] fetchDocumentIconsForDBItems requested for ${formattedIds.length} items`);
 
     const chunkSize = 50;
     try {
@@ -79,7 +79,7 @@ async function fetchDocumentIconsForDBItems(targetIds: string[]): Promise<Record
                 });
             }
         }
-        console.log(`[Data-Debug] fetchDocumentIconsForDBItems successfully retrieved icons for ${Object.keys(itemPropsMap).length} items`);
+        // console.log(`[Data-Debug] fetchDocumentIconsForDBItems successfully retrieved icons for ${Object.keys(itemPropsMap).length} items`);
     } catch (e) {
         console.error("[db-icon-sync] Error fetching document icons for DB bulk insert", e);
     }
@@ -101,7 +101,7 @@ export async function createDatabaseWithBlocks(sourceBlockIds: string[], silent:
         const sql = `SELECT root_id FROM attributes WHERE name IN ('custom-index-command-db', 'custom-index-type-db') AND root_id = (SELECT root_id FROM blocks WHERE id = '${lastBlockId}' LIMIT 1) LIMIT 1`;
         const res = await post("/api/query/sql", { stmt: sql });
         if (res && res.length > 0) {
-            console.log(`[createDatabaseWithBlocks] Detected system DB, forcing skipTemplateCols to true`);
+            // console.log(`[createDatabaseWithBlocks] Detected system DB, forcing skipTemplateCols to true`);
             skipTemplateCols = true;
         }
     } catch (e) {
@@ -298,8 +298,8 @@ export async function createDatabaseWithBlocks(sourceBlockIds: string[], silent:
                 console.log(`[createDatabaseWithBlocks] Adding template cols...`);
                 titleImgKeyId = await ensureKey("title-img", "text", "iconImage");
                 templateKeyId = await ensureKey("template", "text", "iconLayout");
-            } else {
-                console.log(`[createDatabaseWithBlocks] Skipping template cols.`);
+            // } else {
+                // console.log(`[createDatabaseWithBlocks] Skipping template cols.`);
             }
 
             await new Promise(resolve => setTimeout(resolve, 300));

--- a/src/features/data/list/menu.ts
+++ b/src/features/data/list/menu.ts
@@ -54,8 +54,8 @@ export function addDataMenuItems({ detail }: any) {
     const attrNames = outermostList.getAttributeNames();
     const attrMap: any = {};
     attrNames.forEach(name => attrMap[name] = outermostList.getAttribute(name));
-    console.log(`[Data] Sync Menu Check - Outermost [${outermostId}] attrs:`, attrMap);
-    console.log(`[Data] Sync Menu Check - linkedAv:`, linkedAv);
+    // console.log(`[Data] Sync Menu Check - Outermost [${outermostId}] attrs:`, attrMap);
+    // console.log(`[Data] Sync Menu Check - linkedAv:`, linkedAv);
 
     if (linkedAv) {
         menu.addItem({

--- a/src/features/insert-toc/index/action.ts
+++ b/src/features/insert-toc/index/action.ts
@@ -23,14 +23,14 @@ export async function insertAction(targetBlockId?: string) {
     });
 
     if (rs.data[0]?.id != undefined) {
-        console.log("[IndexPlugin] Found existing index:", rs.data[0].id);
+        // console.log("[IndexPlugin] Found existing index:", rs.data[0].id);
         let ial = await client.getBlockAttrs({ id: rs.data[0].id });
         let str = ial.data["custom-index-create"];
 
         let localSettings: any = {};
         try {
             localSettings = JSON.parse(str);
-            console.log("[IndexPlugin] Local settings:", localSettings);
+            // console.log("[IndexPlugin] Local settings:", localSettings);
         } catch (e) {
             console.error("[IndexPlugin] Error parsing settings", e);
         }
@@ -54,10 +54,10 @@ export async function insertAction(targetBlockId?: string) {
         if (mismatch) {
             await new Promise<void>((resolve) => {
                 confirmDialog(i18n.confirmDialog.title, i18n.confirmDialog.content, () => {
-                    console.log("[IndexPlugin] User confirmed update to Global");
+                    // console.log("[IndexPlugin] User confirmed update to Global");
                     resolve();
                 }, () => {
-                    console.log("[IndexPlugin] User kept Local settings");
+                    // console.log("[IndexPlugin] User kept Local settings");
                     // Use local configuration only for THIS operation
                     forceLocalConfig = settings.getMergedConfig(localSettings);
                     resolve();

--- a/src/features/insert-toc/outline/action.ts
+++ b/src/features/insert-toc/outline/action.ts
@@ -23,13 +23,13 @@ export async function insertOutlineAction(targetBlockId?: string) {
     });
 
     if (rs.data[0]?.id != undefined) {
-        console.log("[IndexPlugin] Found existing outline:", rs.data[0].id);
+        // console.log("[IndexPlugin] Found existing outline:", rs.data[0].id);
         let ial = await client.getBlockAttrs({ id: rs.data[0].id });
         let str = ial.data["custom-outline-create"];
         let localSettings: any = {};
         try {
             localSettings = JSON.parse(str);
-            console.log("[IndexPlugin] Local Outline settings:", localSettings);
+            // console.log("[IndexPlugin] Local Outline settings:", localSettings);
         } catch (e) {
             console.error("[IndexPlugin] Error parsing settings", e);
         }
@@ -53,10 +53,10 @@ export async function insertOutlineAction(targetBlockId?: string) {
         if (mismatch) {
             await new Promise<void>((resolve) => {
                 confirmDialog(i18n.confirmDialog.title, i18n.confirmDialog.content, () => {
-                    console.log("[IndexPlugin] User confirmed update to Global (Outline)");
+                    // console.log("[IndexPlugin] User confirmed update to Global (Outline)");
                     resolve();
                 }, () => {
-                    console.log("[IndexPlugin] User kept Local settings (Outline)");
+                    // console.log("[IndexPlugin] User kept Local settings (Outline)");
                     forceLocalConfig = settings.getMergedConfigForOutline(localSettings);
                     resolve();
                 }, i18n.update, i18n.keep);

--- a/src/features/insert-toc/outline/generator.ts
+++ b/src/features/insert-toc/outline/generator.ts
@@ -60,7 +60,7 @@ export function generateOutlineMarkdown(
             name = extractHeadingContent(extraData[id].markdown) || (outline.depth == 0 ? outline.name : outline.content);
             ial = filterIAL(extraData[id].ial);
             pureTextContent = extraData[id].content;
-            console.log(`[Plugin-TOC] SQL提取的纯文本 (id: ${id}):`, pureTextContent);
+            // console.log(`[Plugin-TOC] SQL提取的纯文本 (id: ${id}):`, pureTextContent);
         } else {
             name = outline.depth == 0 ? outline.name : outline.content;
             pureTextContent = name;

--- a/src/features/sqlite/sqlite-manager.ts
+++ b/src/features/sqlite/sqlite-manager.ts
@@ -80,8 +80,8 @@ export async function instantiateAV(avID: string) {
 
     const av = res.av || res;
     const keyValues = av.keyValues || [];
-    console.log(`[SQLiteManager] Fetched AV structure for ${avID}. Columns: ${keyValues.length}`);
-    
+    // console.log(`[SQLiteManager] Fetched AV structure for ${avID}. Columns: ${keyValues.length}`);
+
     if (keyValues.length === 0) return { success: false, message: "Empty/No columns" };
 
     // 1. 映射列头 (增加去重逻辑)
@@ -111,8 +111,8 @@ export async function instantiateAV(avID: string) {
     });
 
     // 2. 清理旧数据并重新建表
-    console.log(`[SQLiteManager] Creating table "${avID}"...`);
-    db.run(`DROP TABLE IF EXISTS "${avID}";`); 
+    // console.log(`[SQLiteManager] Creating table "${avID}"...`);
+    db.run(`DROP TABLE IF EXISTS "${avID}";`);
     db.run(`CREATE TABLE "${avID}" (rowID TEXT PRIMARY KEY, ${columns.map(c => `"${c.name}" TEXT`).join(", ")});`);
 
     // 3. 行归类数据平铺

--- a/src/shared/api-client/index.ts
+++ b/src/shared/api-client/index.ts
@@ -61,7 +61,7 @@ export class BlockService {
                         // content can be empty string for empty P block
                         if (b.type === 'p' && (!b.content || b.content.trim() === '')) {
                             emptyBlockId = b.id;
-                            console.log(`[BlockService] Found empty initial block: ${emptyBlockId}. Will remove after insertion.`);
+                            // console.log(`[BlockService] Found empty initial block: ${emptyBlockId}. Will remove after insertion.`);
                         }
                     }
                 }
@@ -103,7 +103,7 @@ export class BlockService {
                     }
 
                     if (needsSearch) {
-                        console.log(`[BlockService] Block inserted (ID: ${opId}). Searching for inner list...`);
+                        // console.log(`[BlockService] Block inserted (ID: ${opId}). Searching for inner list...`);
                         for (let i = 0; i < 15; i++) {
                             await sleep(500);
                             let childRs = await client.sql({
@@ -166,7 +166,7 @@ export class BlockService {
                         let childRs = await client.sql({ stmt });
                         if (childRs.data && childRs.data[0]) {
                             attrTargetId = childRs.data[0].id;
-                            console.log(`[BlockService] Found new inner list for re-binding: ${attrTargetId}`);
+                            // console.log(`[BlockService] Found new inner list for re-binding: ${attrTargetId}`);
                             foundNew = true;
                             break;
                         }


### PR DESCRIPTION
因为日志输出实在太多了，在调试时造成很多噪音，每次都关插件显得很繁琐，于是干脆从源头上禁用一些日志

本次在 ts 文件 155 个 `console.log` 中禁用了 58 个（总数为 `console.log` 搜索结果数，含已禁用），基本上分为以下三类：

1. 不需处理时打印日志
2. 含敏感或调试信息，如复制粘贴文本、设置项数据、[xx-Debug] 等
3. 邻近代码中出现多个 log 输出

因为这次修改没有参考上下文（全在搜索结果里面跳转），可能有些地方是重要的节点打印一个日志，比如系统启动、系统停止部分日志被禁用，这方面请仔细检查

此外，155 条日志输出是不是有点太多了，很多地方在进入和退出时打印一次输出就够了，出错的地方有 `console.warn` 和 `console.error`，不需要在生产环境中详细说明每一步进行的操作，以及很多调试用的输出在功能正常运行之后就不需要保留，可以直接移除。另外，往编辑器里面粘贴内容、插件内部的设置等在不需要调试的情况下没必要打印。

本次禁用的日志输出仅供参考，最好还是能够精简控制台输出，正常情况下安静一点，调试用输出在用完后移除，或者留在本地，不送进生产环境。也可以让 AI 查找不必要的输出，单独禁用，不合并这个 pr，这个我没问题的。

---

在此之外，对 README 进行了一些修改，根据最新的集市上架规范，README 不能有图片等的相对链接，我把图片改成绝对链接了。